### PR TITLE
Update Minecraft Wiki links to new domain after fork

### DIFF
--- a/src/plateau2minecraft/anvil/block.py
+++ b/src/plateau2minecraft/anvil/block.py
@@ -97,8 +97,8 @@ class Block:
         data
             Numeric data, used to represent variants of the block
         """
-        # See https://minecraft.gamepedia.com/Java_Edition_data_value/Pre-flattening
-        # and https://minecraft.gamepedia.com/Java_Edition_data_value for current values
+        # See https://minecraft.wiki/w/Java_Edition_data_value/Pre-flattening
+        # and https://minecraft.wiki/w/Java_Edition_data_value for current values
         key = f"{block_id}:{data}"
         if key not in LEGACY_ID_MAP:
             raise KeyError(f"Block {key} not found")

--- a/src/plateau2minecraft/anvil/chunk.py
+++ b/src/plateau2minecraft/anvil/chunk.py
@@ -16,7 +16,7 @@ _VERSION_1_17_1 = 2730
 _VERSION_20w17a = 2529
 
 # This version changes how biomes are stored to allow for biomes at different heights
-# https://minecraft.fandom.com/wiki/Java_Edition_19w36a
+# https://minecraft.wiki/w/Java_Edition_19w36a
 _VERSION_19w36a = 2203
 
 # This is the version where "The Flattening" (https://minecraft.gamepedia.com/Java_Edition_1.13/Flattening) happened
@@ -113,7 +113,7 @@ class Chunk:
                 self.version = nbt_data["DataVersion"].value
             except KeyError:
                 # Version is pre-1.9 snapshot 15w32a, so world does not have a Data Version.
-                # See https://minecraft.fandom.com/wiki/Data_version
+                # See https://minecraft.wiki/w/Data_version
                 self.version = None
 
             if self.version > _VERSION_1_17_1:
@@ -469,7 +469,7 @@ class Chunk:
                 # Each biome index refers to a column stored Z then X.
                 index = z * 16 + x
             else:
-                # https://minecraft.fandom.com/wiki/Java_Edition_19w36a
+                # https://minecraft.wiki/w/Java_Edition_19w36a
                 # Get index on the biome list with the order YZX
                 # Each biome index refers to a 4x4 areas here so we do integer division by 4
                 index = (y // 4) * 4 * 4 + (z // 4) * 4 + (x // 4)

--- a/src/plateau2minecraft/anvil/chunk.py
+++ b/src/plateau2minecraft/anvil/chunk.py
@@ -19,7 +19,7 @@ _VERSION_20w17a = 2529
 # https://minecraft.wiki/w/Java_Edition_19w36a
 _VERSION_19w36a = 2203
 
-# This is the version where "The Flattening" (https://minecraft.gamepedia.com/Java_Edition_1.13/Flattening) happened
+# This is the version where "The Flattening" (https://minecraft.wiki/w/Java_Edition_1.13/Flattening) happened
 # where blocks went from numeric ids to namespaced ids (namespace:block_id)
 _VERSION_17w47a = 1451
 
@@ -516,7 +516,7 @@ class Chunk:
             y %= 16
 
         if self.version is None or self.version < _VERSION_17w47a:
-            # Explained in depth here https://minecraft.gamepedia.com/index.php?title=Chunk_format&oldid=1153403#Block_format
+            # Explained in depth here https://minecraft.wiki/w/index.php?title=Chunk_format&oldid=1153403#Block_format
 
             if section is None or "Blocks" not in section:
                 if force_new:

--- a/src/plateau2minecraft/anvil/ro_chunk.py
+++ b/src/plateau2minecraft/anvil/ro_chunk.py
@@ -22,7 +22,7 @@ _VERSION_20w17a = 2529
 # https://minecraft.wiki/w/Java_Edition_19w36a
 _VERSION_19w36a = 2203
 
-# This is the version where "The Flattening" (https://minecraft.gamepedia.com/Java_Edition_1.13/Flattening) happened
+# This is the version where "The Flattening" (https://minecraft.wiki/w/Java_Edition_1.13/Flattening) happened
 # where blocks went from numeric ids to namespaced ids (namespace:block_id)
 _VERSION_17w47a = 1451
 
@@ -283,7 +283,7 @@ class ROChunk:
             y %= 16
 
         if self.version is None or self.version < _VERSION_17w47a:
-            # Explained in depth here https://minecraft.gamepedia.com/index.php?title=Chunk_format&oldid=1153403#Block_format
+            # Explained in depth here https://minecraft.wiki/w/index.php?title=Chunk_format&oldid=1153403#Block_format
 
             if section is None or "Blocks" not in section:
                 if force_new:

--- a/src/plateau2minecraft/anvil/ro_chunk.py
+++ b/src/plateau2minecraft/anvil/ro_chunk.py
@@ -19,7 +19,7 @@ _VERSION_1_17_1 = 2730
 _VERSION_20w17a = 2529
 
 # This version changes how biomes are stored to allow for biomes at different heights
-# https://minecraft.fandom.com/wiki/Java_Edition_19w36a
+# https://minecraft.wiki/w/Java_Edition_19w36a
 _VERSION_19w36a = 2203
 
 # This is the version where "The Flattening" (https://minecraft.gamepedia.com/Java_Edition_1.13/Flattening) happened
@@ -97,7 +97,7 @@ class ROChunk:
             self.version = nbt_data["DataVersion"].value
         except KeyError:
             # Version is pre-1.9 snapshot 15w32a, so world does not have a Data Version.
-            # See https://minecraft.fandom.com/wiki/Data_version
+            # See https://minecraft.wiki/w/Data_version
             self.version = None
 
         if self.version > _VERSION_1_17_1:
@@ -231,7 +231,7 @@ class ROChunk:
                 # Each biome index refers to a column stored Z then X.
                 index = z * 16 + x
             else:
-                # https://minecraft.fandom.com/wiki/Java_Edition_19w36a
+                # https://minecraft.wiki/w/Java_Edition_19w36a
                 # Get index on the biome list with the order YZX
                 # Each biome index refers to a 4x4 areas here so we do integer division by 4
                 index = (y // 4) * 4 * 4 + (z // 4) * 4 + (x // 4)

--- a/src/plateau2minecraft/anvil/section.py
+++ b/src/plateau2minecraft/anvil/section.py
@@ -16,7 +16,7 @@ _VERSION_1_17_1 = 2730
 _VERSION_20w17a = 2529
 
 # This version changes how biomes are stored to allow for biomes at different heights
-# https://minecraft.fandom.com/wiki/Java_Edition_19w36a
+# https://minecraft.wiki/w/Java_Edition_19w36a
 _VERSION_19w36a = 2203
 
 # This is the version where "The Flattening" (https://minecraft.gamepedia.com/Java_Edition_1.13/Flattening) happened

--- a/src/plateau2minecraft/anvil/section.py
+++ b/src/plateau2minecraft/anvil/section.py
@@ -19,7 +19,7 @@ _VERSION_20w17a = 2529
 # https://minecraft.wiki/w/Java_Edition_19w36a
 _VERSION_19w36a = 2203
 
-# This is the version where "The Flattening" (https://minecraft.gamepedia.com/Java_Edition_1.13/Flattening) happened
+# This is the version where "The Flattening" (https://minecraft.wiki/w/Java_Edition_1.13/Flattening) happened
 # where blocks went from numeric ids to namespaced ids (namespace:block_id)
 _VERSION_17w47a = 1451
 


### PR DESCRIPTION
The Minecraft Wiki maintainers have decided to move away from Fandom. More information can be found here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all the URLs to the new domain: minecraft.wiki